### PR TITLE
Removing duplicate entries

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,7 +41,6 @@ SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-Standard: Auto
 Standard: Cpp11
 TabWidth: 2
 UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,6 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackParameters: true


### PR DESCRIPTION
Two of the parameters were duplicated.
For `standard` I selected `Cpp11` beacuse it came second in the list - so I assumed it would overwrite `Auto`.