### PR TITLE
Disabled split_before_logical_operator option

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -2,3 +2,4 @@
 based_on_style = pep8
 blank_line_before_class_docstring = true
 spaces_before_comment = 4
+split_before_logical_operator = false


### PR DESCRIPTION
To make yapf compatible for roslint.