### PR TITLE
Update format file for clang-format-11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,6 +21,7 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
+IncludeBlocks: Preserve
 IndentCaseLabels: true
 IndentFunctionDeclarationAfterType: false
 IndentWidth: 2

--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackParameters: true
 BreakBeforeBinaryOperators: false
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: true
 ColumnLimit: 0
@@ -45,3 +45,23 @@ SpacesInParentheses: false
 Standard: Cpp11
 TabWidth: 2
 UseTab: Never
+
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true

--- a/.clang-format
+++ b/.clang-format
@@ -18,7 +18,7 @@ ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IncludeBlocks: Preserve

--- a/.clang-format
+++ b/.clang-format
@@ -35,6 +35,7 @@ PenaltyBreakString: 1
 PenaltyExcessCharacter: 1000
 PenaltyReturnTypeOnItsOwnLine: 90
 PointerAlignment: Left
+SortIncludes: false
 SpaceAfterControlStatementKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceInEmptyParentheses: false

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When you want to put only one element per line, please add a comma after the las
 
 
 With last comma:
-```
+```cpp
   std::vector<int> a =
       {
           1,

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ $ yapf --recursive --in-place --parallel $DIR (Specify a target directory)
 
 ## cpp
 
-Use clang-format 3.7 and `.clang-format` in this repository.
-(later clang-format has [the bug](https://www.mail-archive.com/llvm-bugs@lists.llvm.org/msg05471.html) around lambda functions)
+Use clang-format 11 and `.clang-format` in this repository.
+You can install clang-format 11 with apt if you are using Ubuntu 20.04.
+```
+$ sudo apt install clang-format-11
+```
+
 
 Make symlink to .clang-format file in your workspace directory.
 ```shell
@@ -20,26 +24,33 @@ $ ln -s /path/to/ros_style/.clang-format /path/to/your/workspace/
 
 The cpp codes must be checked by [roslint cpplint](http://wiki.ros.org/roslint).
 
-### building clang-format 3.7
+### Notes
 
-```shell
-$ cd ~/Downloads  # change as you like
-$ wget http://releases.llvm.org/3.7.1/llvm-3.7.1.src.tar.xz
-$ tar xJfv llvm-3.7.1.src.tar.xz
-$ cd llvm-3.7.1.src/tools
-$ wget http://releases.llvm.org/3.7.1/cfe-3.7.1.src.tar.xz
-$ tar xJfv cfe-3.7.1.src.tar.xz
-$ cd ..
-$ mkdir build
-$ cd build
-$ cmake .. -DCMAKE_BUILD_TYPE=Release
-$ make clang-format
-$ sudo cp bin/clang-format /usr/local/bin/
+- Formatting of initializer list
+
+When you want to put only one element per line, please add comma after the last element to format them correctly.
+
+
+With last comma:
+```
+  std::vector<int> a =
+      {
+          1,
+          2,
+          3,
+      };
 ```
 
-clang-format is installed under /usr/local/bin.
+Without last comma:
+```
+  std::vector<int> a =
+      {
+          1,
+          2,
+          3};
+```
 
-### note
+- Line length limit
 
-Line length limit (ColumnLimit) is disabled in this config.
+`ColumnLimit` parameter is disabled in this config.
 Please check it by using [roslint cpplint](http://wiki.ros.org/roslint).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With last comma:
 ```
 
 Without last comma:
-```
+```cpp
   std::vector<int> a =
       {
           1,

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@
 $ yapf --recursive --in-place --parallel $DIR (Specify a target directory)
 ```
 
+We recommend to use `yapf 0.24.0`.
+
+```shell
+$ pip3 install yapf==0.24.0
+```
+
 ## cpp
 
 Use clang-format 11 and `.clang-format` in this repository.
 You can install clang-format 11 with apt if you are using Ubuntu 20.04.
-```
+```shell
 $ sudo apt install clang-format-11
 ```
 
@@ -28,7 +34,7 @@ The cpp codes must be checked by [roslint cpplint](http://wiki.ros.org/roslint).
 
 - Formatting of initializer list
 
-When you want to put only one element per line, please add comma after the last element to format them correctly.
+When you want to put only one element per line, please add a comma after the last element to format them correctly.
 
 
 With last comma:


### PR DESCRIPTION
Options list: https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html

In order to keep consistency with clang-format 3.7, sorting of include files are disabled.

Formatting of initializer list is slightly changed.
We can choose two types of formatting.
```
  std::vector<int> a =
      {
          1,
          2,
          3,
      };
``` 
```
  std::vector<int> a = {1, 2, 3};
```
Note that the second one does not have comma after `3`.

The following style, which we often use, is not allowed.
```
  std::vector<int> a =
      {
          1, 2, 3
      };
``` 


