### PR TITLE
Add configuration files for python linters and formatters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+ignore = ANN101, E203, W503

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+ignore_missing_imports = True
+implicit_reexport = True
+python_version = 3.9
+show_column_numbers = True
+show_error_codes = True
+strict = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
Settings for `flake8`, `mypy`, `isort`, and `black` are added.