### PR TITLE
Fix typecheck workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
       - name: Remove ignored paths
         run: find . -name .lint-ignore | xargs dirname | xargs rm -rf
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9.5'
           architecture: x64
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
       - name: Remove ignored paths
         run: find . -name .lint-ignore | xargs dirname | xargs rm -rf
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9.5'
           architecture: x64

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -111,13 +111,14 @@ jobs:
               python_files+=(${file})
             fi
           done
-          echo "checking ${python_files[@]}"
+          echo "found ${#python_files[@]} python file(s)"
 
           if [ ${#python_files[@]} -eq 0 ]; then
             echo "passed=true" >> ${GITHUB_OUTPUT}
             exit 0
           fi
 
+          echo "checking ${python_files[@]}"
           # workaround to get mypy to figure out the types it should install
           mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
           mypy --install-types --non-interactive

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -96,10 +96,6 @@ jobs:
         run: |
           curl -LOJs https://raw.githubusercontent.com/seqsense/ros_style/${{ inputs.style-branch }}/mypy.ini
 
-          # workaround to get mypy to figure out the types it should install
-          mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
-          mypy --install-types --non-interactive
-
           cmd="mypy --config-file mypy.ini --scripts-are-modules"
 
           files_to_check="${{ inputs.files }}"
@@ -116,6 +112,16 @@ jobs:
             fi
           done
           echo "checking ${python_files[@]}"
+
+          if [ ${#python_files[@]} -eq 0 ]; then
+            echo "passed=true" >> ${GITHUB_OUTPUT}
+            exit 0
+          fi
+
+          # workaround to get mypy to figure out the types it should install
+          mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
+          mypy --install-types --non-interactive
+
           output="$(${cmd} ${python_files[@]} | tee /dev/stderr)"
           result="$(echo "${output}" | tail -n 1)"
 


### PR DESCRIPTION
The main goal of this PR is to fix the following error:
```
error: Can't determine which types to install with no files to check (and no cache from previous mypy run)
Error: Process completed with exit code 2.
```
It occurs when `mypy` is ran on a repository which does not contain any python file.

In addition, the `setup-python` action is upgraded to address the warning about the use of the deprecated `set-output` command.