### PR TITLE
Fix cpp workflow: files option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
   cpp-fail:
     uses: ./.github/workflows/cpp.yml
     with:
+      files: ./test/pass.cpp ./test/fail.cpp
       style-branch: ${{ github.head_ref }}
       continue-on-error: true
   cpp-fail-clang-format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
   cpp-fail:
     uses: ./.github/workflows/cpp.yml
     with:
-      files: ./test/pass.cpp ./test/fail.cpp
       style-branch: ${{ github.head_ref }}
       continue-on-error: true
   cpp-fail-clang-format:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -46,7 +46,7 @@ jobs:
           set -eo pipefail
 
           files_to_check="${{ inputs.files }}"
-          if [ -z ${files_to_check} ]; then
+          if [[ -z ${files_to_check} ]]; then
             files_to_check=$(find . -name "*.cpp" -o -name "*.h")
           fi
 
@@ -81,7 +81,7 @@ jobs:
           set -eo pipefail
 
           files_to_check="${{ inputs.files }}"
-          if [ -z ${files_to_check} ]; then
+          if [[ -z ${files_to_check} ]]; then
             files_to_check=$(find . -name "*.cpp" -o -name "*.h")
           fi
 

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -46,7 +46,7 @@ jobs:
           set -eo pipefail
 
           files_to_check="${{ inputs.files }}"
-          if [[ -z ${files_to_check} ]]; then
+          if [ -z "${files_to_check}" ]; then
             files_to_check=$(find . -name "*.cpp" -o -name "*.h")
           fi
 
@@ -81,7 +81,7 @@ jobs:
           set -eo pipefail
 
           files_to_check="${{ inputs.files }}"
-          if [[ -z ${files_to_check} ]]; then
+          if [ -z "${files_to_check}" ]; then
             files_to_check=$(find . -name "*.cpp" -o -name "*.h")
           fi
 


### PR DESCRIPTION
This PR addresses a minor issue with the condition check on the `cpp` workflow `files` option (https://github.com/seqsense/ros_style/actions/runs/3494547477/jobs/5850411768#step:5:21)

```
Run set -eo pipefail
/home/runner/work/_temp/8340a872-2fb9-4a38-96fe-8800cd734c53.sh: line 4: [: ./test/pass.cpp: binary operator expected
```