### PR TITLE
Fix python workflow on ubuntu 22.04

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
 
           for file in ${files_to_check}; do
             filetype=$(file -b --mime-type ${file})
-            if echo ${filetype} | grep -qE "text/x-python"; then
+            if echo ${filetype} | grep -qE "text/x-python|text/x-script.python"; then
               echo "checking ${file}"
               ${cmd} ${file} \
                 | sed 's|^\(\S\+\):\([0-9]\+\):\([0-9]\+\): \(.*\)$|::error file=\1,line=\2,col=\3::\4\n\0|'
@@ -107,7 +107,7 @@ jobs:
 
           for file in ${files_to_check}; do
             filetype=$(file -b --mime-type ${file})
-            if echo ${filetype} | grep -qE "text/x-python"; then
+            if echo ${filetype} | grep -qE "text/x-python|text/x-script.python"; then
               python_files+=(${file})
             fi
           done

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
         run: find . -name .lint-ignore | xargs dirname | xargs rm -rf
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.5'
+          python-version: '3.9'
           architecture: x64
       - name: Install flake8 and plugins
         run: pip install --disable-pip-version-check flake8-black==0.3.3 flake8-isort==4.1.1
@@ -86,7 +86,7 @@ jobs:
         run: find . -name .lint-ignore | xargs dirname | xargs rm -rf
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.5'
+          python-version: '3.9'
           architecture: x64
       - name: Install mypy
         run: pip install --disable-pip-version-check mypy==0.950


### PR DESCRIPTION
This PR fixes the following error (https://github.com/seqsense/ros_style/actions/runs/3494547477/jobs/5850412281):
![image](https://user-images.githubusercontent.com/66578286/202632761-b258a28b-6987-47d7-9d4a-0867da3c052d.png)

According to https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json, `python 3.9.5` is not available on `ubuntu 22.04` (environment set up for the jobs).

```json
  {
    "version": "3.9.5",
    "stable": true,
    "release_url": "https://github.com/actions/python-versions/releases/tag/3.9.5-109482",
    "files": [
      {
        "filename": "python-3.9.5-darwin-x64.tar.gz",
        "arch": "x64",
        "platform": "darwin",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-darwin-x64.tar.gz"
      },
      {
        "filename": "python-3.9.5-linux-16.04-x64.tar.gz",
        "arch": "x64",
        "platform": "linux",
        "platform_version": "16.04",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-linux-16.04-x64.tar.gz"
      },
      {
        "filename": "python-3.9.5-linux-18.04-x64.tar.gz",
        "arch": "x64",
        "platform": "linux",
        "platform_version": "18.04",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-linux-18.04-x64.tar.gz"
      },
      {
        "filename": "python-3.9.5-linux-20.04-x64.tar.gz",
        "arch": "x64",
        "platform": "linux",
        "platform_version": "20.04",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-linux-20.04-x64.tar.gz"
      },
      {
        "filename": "python-3.9.5-win32-x64.zip",
        "arch": "x64",
        "platform": "win32",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-win32-x64.zip"
      },
      {
        "filename": "python-3.9.5-win32-x86.zip",
        "arch": "x86",
        "platform": "win32",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.5-109482/python-3.9.5-win32-x86.zip"
      }
    ]
  },
```

In `ubuntu 22.04`, python scripts/modules file type is `text/x-script.python` vs `text/x-python` in earlier `ubuntu` version.