### PR TITLE
Python typecheck: install type stub packages listed in a dedicated file if provided

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -119,9 +119,14 @@ jobs:
           fi
 
           echo "checking ${python_files[@]}"
-          # workaround to get mypy to figure out the types it should install
-          mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
-          mypy --install-types --non-interactive
+
+          if [ -f ".mypy-stub-pkgs" ]; then
+            pip install -r .mypy-stub-pkgs
+          else
+            # workaround to get mypy to figure out the types it should install
+            mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
+            mypy --install-types --non-interactive
+          fi
 
           output="$(${cmd} ${python_files[@]} | tee /dev/stderr)"
           result="$(echo "${output}" | tail -n 1)"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -120,13 +120,15 @@ jobs:
 
           echo "checking ${python_files[@]}"
 
+          # install explicitly listed type stub packages
           if [ -f ".mypy-stub-pkgs" ]; then
             pip install -r .mypy-stub-pkgs
-          else
-            # workaround to get mypy to figure out the types it should install
-            mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
-            mypy --install-types --non-interactive
           fi
+
+          # workaround to get mypy to figure out the types it should install
+          # note that it does not upgrade already installed packages
+          mypy --config-file mypy.ini . > /dev/null 2> /dev/null || true
+          mypy --install-types --non-interactive
 
           output="$(${cmd} ${python_files[@]} | tee /dev/stderr)"
           result="$(echo "${output}" | tail -n 1)"


### PR DESCRIPTION
In some cases, it is needed to specify the versions of the type stub packages to install for `mypy`.