### PR TITLE
cpp workflow: check .hpp files

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,5 +1,3 @@
-name: ci
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -47,7 +47,7 @@ jobs:
 
           files_to_check="${{ inputs.files }}"
           if [ -z "${files_to_check}" ]; then
-            files_to_check=$(find . -name "*.cpp" -o -name "*.h")
+            files_to_check=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp")
           fi
 
           (


### PR DESCRIPTION
The primary goal of this PR is to consider the `.hpp` files when running the `cpp` workflow. The name of the workflow has been removed as it was not really relevant and to be consistent with `python.yml`.