### PR TITLE
Python workflow: pin black version to 25.1.0

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.10'
           architecture: x64
       - name: Install flake8 and plugins
-        run: pip install --disable-pip-version-check flake8-black==0.3.5 flake8-isort==5.0.3
+        run: pip install --disable-pip-version-check black==25.1.0 flake8-black==0.3.5 flake8-isort==5.0.3
       - name: Install flake8-annotations
         if: inputs.run-typecheck
         run: pip install --disable-pip-version-check flake8-annotations==2.9.1


### PR DESCRIPTION
Using the latest version of `black` (25.9.0) seems to cause problem such as `BLK900 Failed to load file: decode_bytes() missing required argument 'mode' (pos 2)`